### PR TITLE
Added support for check ttl (which replaced the watchdog_timer concept)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ result_dict = {
     'alert_after': '5m',
     'check_every': '1m',
     'realert_every': -1,
-    'watchdog_timer': None
+    'ttl': None
 }
 pysensu_yelp.send_event(**result_dict)
 ```

--- a/pysensu_yelp/__init__.py
+++ b/pysensu_yelp/__init__.py
@@ -57,7 +57,7 @@ def human_to_seconds(string):
 
 def send_event(name, runbook, status, output, team, page=False, tip=None, notification_email=None,
                check_every='5m', realert_every=1, alert_after='0s', dependencies=[],
-               irc_channels=None, ticket=False, project=None, source=None, watchdog_timer=None):
+               irc_channels=None, ticket=False, project=None, source=None, ttl=None):
     """Send a new event with the given information. Requires a name, runbook, status code,
     and event output, but the other keys are kwargs and have defaults.
     
@@ -106,9 +106,11 @@ def send_event(name, runbook, status, output, team, page=False, tip=None, notifi
     :type source: str
     :param source: Allows "masquerading" the source value of the event, otherwise comes from the fqdn of the host it runs on.
 
-    :type watchdog_timer: str
-    :param watchdog_timer: A human readable time unit to be checked by Sensu Watchdog. Defaults to None.
-
+    :type ttl: str
+    :param ttl: A human readable time unit to set the check TTL.
+    If Sensu does not hear from the check after this time unit,
+    Sensu will spawn a new failing event! (aka check staleness)
+    Defaults to None.
 
     """
     if not (name and team):
@@ -134,7 +136,7 @@ def send_event(name, runbook, status, output, team, page=False, tip=None, notifi
         'ticket': ticket,
         'project': project,
         'source': source,
-        'watchdog_timer': human_to_seconds(watchdog_timer),
+        'ttl': human_to_seconds(ttl),
     }
     if irc_channels:
         result_dict['irc_channels'] = irc_channels

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pysensu-yelp',
-    version='0.1.9',
+    version='0.1.10',
     provides=['pysensu_yelp'],
     description='Emits Yelp-flavored Sensu events to a Sensu Client',
     url='https://gitweb.yelpcorp.com/?p=pysensu-yelp.git',

--- a/tests/test_pysensu_yelp.py
+++ b/tests/test_pysensu_yelp.py
@@ -21,7 +21,7 @@ class TestPySensuYelp:
     test_ticket = True
     test_project = 'TEST_SENSU'
     test_source = 'source.test'
-    test_watchdog_timer = '30M'
+    test_ttl = '30M'
 
 
     event_dict = {
@@ -41,7 +41,7 @@ class TestPySensuYelp:
         'ticket': test_ticket,
         'project': test_project,
         'source': test_source,
-        'watchdog_timer': pysensu_yelp.human_to_seconds(test_watchdog_timer),
+        'ttl': pysensu_yelp.human_to_seconds(test_ttl),
     }
     event_dict['irc_channels'] = test_irc_channels
     event_hash = json.dumps(event_dict)
@@ -71,7 +71,7 @@ class TestPySensuYelp:
                                     ticket=self.test_ticket,
                                     project=self.test_project,
                                     source=self.test_source,
-                                    watchdog_timer=self.test_watchdog_timer)
+                                    ttl=self.test_ttl)
             skt_patch.assert_called_once()
             magic_skt.connect.assert_called_once_with(pysensu_yelp.SENSU_ON_LOCALHOST)
             magic_skt.sendall.assert_called_once_with(self.event_hash + '\n')
@@ -93,7 +93,7 @@ class TestPySensuYelp:
                                         ticket=self.test_ticket,
                                         project=self.test_project,
                                         source=self.test_source,
-                                        watchdog_timer=self.test_watchdog_timer)
+                                        ttl=self.test_ttl)
             skt_patch.assert_not_called()
 
     def test_no_special_characters_in_name(self):
@@ -114,4 +114,4 @@ class TestPySensuYelp:
                                             ticket=self.test_ticket,
                                             project=self.test_project,
                                             source=self.test_source,
-                                            watchdog_timer=self.test_watchdog_timer)
+                                            ttl=self.test_ttl)


### PR DESCRIPTION
Sensu .19 and up support the concept of a check ttl.
I have a few PR's upstream to make it usuable for us at Yelp, but till then I would like to get our client library instrumented so I can support testing it.

This is close to being a real thing!!!

cc @trumpcard @mrtyler @pauloconnor 