### PR TITLE
Allow human_to_seconds to handle None correctly

### DIFF
--- a/pysensu_yelp/__init__.py
+++ b/pysensu_yelp/__init__.py
@@ -41,6 +41,8 @@ def human_to_seconds(string):
     interval_regex = re.compile("^(?P<value>[0-9]+)(?P<unit>[{0}])".format("".join(interval_dict.keys())))
     seconds = 0
 
+    if string is None:
+        return None
     while string:
         match = interval_regex.match(string)
         if match:

--- a/tests/test_pysensu_yelp.py
+++ b/tests/test_pysensu_yelp.py
@@ -52,6 +52,7 @@ class TestPySensuYelp:
         assert pysensu_yelp.human_to_seconds('1M1m') == 2592060
         assert pysensu_yelp.human_to_seconds('1Y1M1W1D1h1m1s') == 34822861
         assert pysensu_yelp.human_to_seconds('0s') == 0
+        assert pysensu_yelp.human_to_seconds(None) == None
 
         pytest.raises(Exception, pysensu_yelp.human_to_seconds, ('ss'))
         pytest.raises(Exception, pysensu_yelp.human_to_seconds, ('0q'))


### PR DESCRIPTION
When the `ttl` of a check is `None`, that does *not* mean "0s", it means Null.

Same should go for any setting that is None.