### PR TITLE
Big cleanup and allow other hosts to be used besides localhost

### DIFF
--- a/pysensu_yelp/__init__.py
+++ b/pysensu_yelp/__init__.py
@@ -5,7 +5,6 @@ import socket
 import re
 from ordereddict import OrderedDict
 
-SENSU_ON_LOCALHOST = ('localhost', 3030)
 
 # Status codes for sensu checks
 # Code using this module can write pysensu_yelp.Status.OK, etc
@@ -17,7 +16,9 @@ Status = type('Enum', (), {
     'UNKNOWN':  3
 })
 
-# Copied from: http://thomassileo.com/blog/2013/03/31/how-to-convert-seconds-to-human-readable-interval-back-and-forth-with-python/
+
+# Copied from:
+# http://thomassileo.com/blog/2013/03/31/how-to-convert-seconds-to-human-readable-interval-back-and-forth-with-python/
 interval_dict = OrderedDict([("Y", 365*86400),  # 1 year
                              ("M", 30*86400),   # 1 month
                              ("W", 7*86400),    # 1 week
@@ -25,6 +26,7 @@ interval_dict = OrderedDict([("Y", 365*86400),  # 1 year
                              ("h", 3600),       # 1 hour
                              ("m", 60),         # 1 minute
                              ("s", 1)])         # 1 second
+
 
 def human_to_seconds(string):
     """Convert internal string like 1M, 1Y3M, 3W to seconds.
@@ -57,12 +59,29 @@ def human_to_seconds(string):
             raise Exception(interval_exc)
     return seconds
 
-def send_event(name, runbook, status, output, team, page=False, tip=None, notification_email=None,
-               check_every='5m', realert_every=1, alert_after='0s', dependencies=[],
-               irc_channels=None, ticket=False, project=None, source=None, ttl=None):
+
+def send_event(name,
+               runbook,
+               status,
+               output,
+               team,
+               page=False,
+               tip=None,
+               notification_email=None,
+               check_every='5m',
+               realert_every=1,
+               alert_after='0s',
+               dependencies=[],
+               irc_channels=None,
+               ticket=False,
+               project=None,
+               source=None,
+               ttl=None,
+               sensu_host='localhost',
+               sensu_port=3030):
     """Send a new event with the given information. Requires a name, runbook, status code,
     and event output, but the other keys are kwargs and have defaults.
-    
+
     :type name: str
     :param name: Name of the check
 
@@ -146,7 +165,7 @@ def send_event(name, runbook, status, output, team, page=False, tip=None, notifi
     json_hash = json.dumps(result_dict)
     sock = socket.socket()
     try:
-        sock.connect(SENSU_ON_LOCALHOST)
+        sock.connect(sensu_host, sensu_port)
         sock.sendall(json_hash + '\n')
     finally:
         sock.close()

--- a/pysensu_yelp/__init__.py
+++ b/pysensu_yelp/__init__.py
@@ -162,7 +162,7 @@ def send_event(name,
     json_hash = json.dumps(result_dict)
     sock = socket.socket()
     try:
-        sock.connect(sensu_host, sensu_port)
+        sock.connect((sensu_host, sensu_port))
         sock.sendall(json_hash + '\n')
     finally:
         sock.close()

--- a/tests/test_pysensu_yelp.py
+++ b/tests/test_pysensu_yelp.py
@@ -3,8 +3,8 @@ import mock
 import json
 import pytest
 
-class TestPySensuYelp:
 
+class TestPySensuYelp:
     test_name = 'then_i_saw_her_face'
     test_runbook = 'now_im_a_believer'
     test_status = 0
@@ -22,7 +22,6 @@ class TestPySensuYelp:
     test_project = 'TEST_SENSU'
     test_source = 'source.test'
     test_ttl = '30M'
-
 
     event_dict = {
         'name': test_name,
@@ -73,8 +72,31 @@ class TestPySensuYelp:
                                     project=self.test_project,
                                     source=self.test_source,
                                     ttl=self.test_ttl)
-            skt_patch.assert_called_once()
-            magic_skt.connect.assert_called_once_with(pysensu_yelp.SENSU_ON_LOCALHOST)
+            assert skt_patch.call_count == 1
+            magic_skt.connect.assert_called_once_with('localhost', 3030)
+            magic_skt.sendall.assert_called_once_with(self.event_hash + '\n')
+            magic_skt.close.assert_called_once()
+
+    def test_send_event_custom_sensu_host(self):
+        magic_skt = mock.MagicMock()
+        with mock.patch('socket.socket', return_value=magic_skt) as skt_patch:
+            pysensu_yelp.send_event(self.test_name, self.test_runbook,
+                                    self.test_status, self.test_output,
+                                    self.test_team, page=self.test_page, tip=self.test_tip,
+                                    notification_email=self.test_notification_email,
+                                    check_every=self.test_check_every,
+                                    realert_every=self.test_realert_every,
+                                    alert_after=self.test_alert_after,
+                                    dependencies=self.test_dependencies,
+                                    irc_channels=self.test_irc_channels,
+                                    ticket=self.test_ticket,
+                                    project=self.test_project,
+                                    source=self.test_source,
+                                    ttl=self.test_ttl,
+                                    sensu_host='testhost',
+                                    sensu_port=666)
+            assert skt_patch.call_count == 1
+            magic_skt.connect.assert_called_once_with('testhost', 666)
             magic_skt.sendall.assert_called_once_with(self.event_hash + '\n')
             magic_skt.close.assert_called_once()
 
@@ -99,7 +121,7 @@ class TestPySensuYelp:
 
     def test_no_special_characters_in_name(self):
         magic_skt = mock.MagicMock()
-        with mock.patch('socket.socket', return_value=magic_skt) as skt_patch:
+        with mock.patch('socket.socket', return_value=magic_skt):
             for special_char in '!@#$%^&*() ;",<>=+[]':
                 test_name = self.test_name + special_char
                 with pytest.raises(ValueError):

--- a/tests/test_pysensu_yelp.py
+++ b/tests/test_pysensu_yelp.py
@@ -73,7 +73,7 @@ class TestPySensuYelp:
                                     source=self.test_source,
                                     ttl=self.test_ttl)
             assert skt_patch.call_count == 1
-            magic_skt.connect.assert_called_once_with('localhost', 3030)
+            magic_skt.connect.assert_called_once_with(('localhost', 3030))
             magic_skt.sendall.assert_called_once_with(self.event_hash + '\n')
             magic_skt.close.assert_called_once()
 
@@ -96,7 +96,7 @@ class TestPySensuYelp:
                                     sensu_host='testhost',
                                     sensu_port=666)
             assert skt_patch.call_count == 1
-            magic_skt.connect.assert_called_once_with('testhost', 666)
+            magic_skt.connect.assert_called_once_with(('testhost', 666))
             magic_skt.sendall.assert_called_once_with(self.event_hash + '\n')
             magic_skt.close.assert_called_once()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,18 @@
 [tox]
 envlist = py26,py27,p34
 
+[flake8]
+# TODO: fix long lines
+max-line-length = 2000
+exclude = docs/*
+
 [testenv]
 deps=
     -rrequirements.txt
     pytest
-    mock
+    mock==1.0.1
+    pep8
+    flake8
 commands=
+    flake8
     py.test {posargs:tests}


### PR DESCRIPTION
In preparation to allow people to send sensu events to yocalhost from inside docker (once that is portforwarded/synapse/whatever), I would like to make the library flexible enough to do that.

Also adding flake8

cc @mrtyler @bobtfish 

Internal ticket OPS-4459