### PR TITLE
fix OrderedDict import in python34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ script:
 env:
   - TOXENV=py26
   - TOXENV=py27
-# OrderedDict doesn't work? Needs investigation
-#  - TOXENV=py34
+  - TOXENV=py34

--- a/pysensu_yelp/__init__.py
+++ b/pysensu_yelp/__init__.py
@@ -3,7 +3,10 @@
 import json
 import socket
 import re
-from ordereddict import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 
 # Status codes for sensu checks

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,p34
+envlist = py26,py27,py34
 
 [flake8]
 # TODO: fix long lines


### PR DESCRIPTION
The `ordereddict` package doesn't work in python3, but we only need this backport for py26.