### PR TITLE
py36 support

### DIFF
--- a/pysensu_yelp/__init__.py
+++ b/pysensu_yelp/__init__.py
@@ -7,6 +7,8 @@ import subprocess
 import re
 import sys
 
+import six
+
 """
 pysensu-yelp
 ============
@@ -190,7 +192,7 @@ def send_event(
     sensu_port=3030,
 ):
     """Send a new event with the given information. Requires a name, runbook,
-    status code, and event output, but the other keys are kwargs and have
+    status code, event output, and team but the other keys are kwargs and have
     defaults.
 
     :type name: str
@@ -200,7 +202,7 @@ def send_event(
     :param runbook: The runbook associated with the check
 
     :type status: int
-    :param status: Exist status code, 0,1,2,3. Must comply with the Nagios
+    :param status: Exit status code, 0,1,2,3. Must comply with the Nagios
                    conventions. See `the Sensu docs <https://sensuapp.org/docs/latest/checks#sensu-check-specification>`_
                    for the exact specification.
 
@@ -319,10 +321,11 @@ def send_event(
         result_dict['irc_channels'] = irc_channels
 
     json_hash = json.dumps(result_dict)
+
     sock = socket.socket()
     try:
         sock.connect((sensu_host, sensu_port))
-        sock.sendall(json_hash + '\n')
+        sock.sendall(six.b(json_hash) + b'\n')
     finally:
         sock.close()
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
     author='Yelp Operations Team',
     author_email='operations@yelp.com',
     packages=find_packages(exclude=['tests']),
-    install_requires=[],
+    install_requires=['six'],
     license='Copyright Yelp 2014, all rights reserved',
 )

--- a/tests/test_pysensu_yelp.py
+++ b/tests/test_pysensu_yelp.py
@@ -2,6 +2,7 @@ import pysensu_yelp
 import mock
 import json
 import pytest
+import six
 
 
 class TestPySensuYelp:
@@ -45,7 +46,7 @@ class TestPySensuYelp:
         'ttl': pysensu_yelp.human_to_seconds(test_ttl),
     }
     event_dict['irc_channels'] = test_irc_channels
-    event_hash = json.dumps(event_dict)
+    event_hash = six.b(json.dumps(event_dict))
 
     def test_human_to_seconds(self):
         assert pysensu_yelp.human_to_seconds('1s') == 1
@@ -77,7 +78,7 @@ class TestPySensuYelp:
                                     ttl=self.test_ttl)
             assert skt_patch.call_count == 1
             magic_skt.connect.assert_called_once_with(('169.254.255.254', 3030))
-            magic_skt.sendall.assert_called_once_with(self.event_hash + '\n')
+            magic_skt.sendall.assert_called_once_with(self.event_hash + b'\n')
             magic_skt.close.assert_called_once()
 
     def test_send_event_custom_sensu_host(self):
@@ -101,7 +102,7 @@ class TestPySensuYelp:
                                     sensu_port=666)
             assert skt_patch.call_count == 1
             magic_skt.connect.assert_called_once_with(('testhost', 666))
-            magic_skt.sendall.assert_called_once_with(self.event_hash + '\n')
+            magic_skt.sendall.assert_called_once_with(self.event_hash + b'\n')
             magic_skt.close.assert_called_once()
 
     def test_send_event_no_team(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py34,py36
 
 [flake8]
 # TODO: fix long lines


### PR DESCRIPTION
socket.sendall() requires bytes in py36
```
  File "/opt/venvs/cascade/lib/python3.6/site-packages/pysensu_yelp/__init__.py", line 324, in send_event
    sock.sendall(json_hash + '\n')
TypeError: a bytes-like object is required, not 'str'
```