### PR TITLE
Allow custom parameters to be added to the results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
 python:
-- 2.7
+- 3.6
 install:
 - pip install tox
 script:
 - tox
 env:
 - TOXENV=py27
-- TOXENV=py34
+- TOXENV=py36
 
 deploy:
   provider: pypi

--- a/pysensu_yelp/__init__.py
+++ b/pysensu_yelp/__init__.py
@@ -194,6 +194,7 @@ def send_event(
     sensu_port=3030,
     component=None,
     description=None,
+    cluster_name=None
 ):
     """Send a new event with the given information. Requires a name, runbook,
     status code, event output, and team but the other keys are kwargs and have
@@ -312,6 +313,8 @@ def send_event(
                         include information on what the check means or why was it
                         created.
 
+    :type cluster_name: str
+    :param description: To be added to the result output, used by cluster checks
 
     Note on TTL events and alert_after:
     ``alert_after`` and ``check_every`` only really make sense on events that are created
@@ -363,6 +366,9 @@ def send_event(
 
     if description is not None:
         result_dict['description'] = description
+
+    if cluster_name is not None:
+        result_dict['cluster_name'] = cluster_name
 
     json_hash = json.dumps(result_dict)
 

--- a/tests/test_pysensu_yelp.py
+++ b/tests/test_pysensu_yelp.py
@@ -26,6 +26,7 @@ class TestPySensuYelp:
     test_source = 'source.test'
     test_tags = ['tag1', 'tag2']
     test_ttl = '30M'
+    test_cluster_name = 'test_cluster'
 
     event_dict = {
         'name': test_name,
@@ -50,6 +51,7 @@ class TestPySensuYelp:
     }
     event_dict['irc_channels'] = test_irc_channels
     event_dict['slack_channels'] = test_slack_channels
+    event_dict['cluster_name'] = test_cluster_name
     event_hash = six.b(json.dumps(event_dict))
 
     def test_human_to_seconds(self):
@@ -81,7 +83,8 @@ class TestPySensuYelp:
                                     priority=self.test_priority,
                                     source=self.test_source,
                                     tags=self.test_tags,
-                                    ttl=self.test_ttl)
+                                    ttl=self.test_ttl,
+                                    cluster_name=self.test_cluster_name)
             assert skt_patch.call_count == 1
             magic_skt.connect.assert_called_once_with(('169.254.255.254', 3030))
             magic_skt.sendall.assert_called_once_with(self.event_hash + b'\n')
@@ -107,7 +110,8 @@ class TestPySensuYelp:
                                     tags=self.test_tags,
                                     ttl=self.test_ttl,
                                     sensu_host='testhost',
-                                    sensu_port=666)
+                                    sensu_port=666,
+                                    cluster_name=self.test_cluster_name)
             assert skt_patch.call_count == 1
             magic_skt.connect.assert_called_once_with(('testhost', 666))
             magic_skt.sendall.assert_called_once_with(self.event_hash + b'\n')
@@ -132,7 +136,8 @@ class TestPySensuYelp:
                                         priority=self.test_priority,
                                         source=self.test_source,
                                         tags=self.test_tags,
-                                        ttl=self.test_ttl)
+                                        ttl=self.test_ttl,
+                                        cluster_name=self.test_cluster_name)
             skt_patch.assert_not_called()
 
     def test_no_special_characters_in_name(self):
@@ -156,4 +161,5 @@ class TestPySensuYelp:
                                             priority=self.test_priority,
                                             source=self.test_source,
                                             tags=self.test_tags,
-                                            ttl=self.test_ttl)
+                                            ttl=self.test_ttl,
+                                            cluster_name=self.test_cluster_name)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py36
+envlist = py27,py36
 
 [flake8]
 # TODO: fix long lines


### PR DESCRIPTION
As it's needed by some custom check code like cluster-check

also remove py34 as travis ci has moved to xenial
