### PR TITLE
Add a custom issuetype optional parameter

### DIFF
--- a/pysensu_yelp/__init__.py
+++ b/pysensu_yelp/__init__.py
@@ -194,7 +194,8 @@ def send_event(
     sensu_port=3030,
     component=None,
     description=None,
-    cluster_name=None
+    cluster_name=None,
+    issuetype=None,
 ):
     """Send a new event with the given information. Requires a name, runbook,
     status code, event output, and team but the other keys are kwargs and have
@@ -314,7 +315,11 @@ def send_event(
                         created.
 
     :type cluster_name: str
-    :param description: To be added to the result output, used by cluster checks
+    :param cluster_name: To be added to the result output, used by cluster checks
+
+    :type issuetype: str
+    :param issuetype: An issue type name such as "Incident" or "Task" to use for
+                      newly created JIRA tickets from sensu checks.
 
     Note on TTL events and alert_after:
     ``alert_after`` and ``check_every`` only really make sense on events that are created
@@ -354,6 +359,7 @@ def send_event(
         'source': source,
         'tags': tags,
         'ttl': human_to_seconds(ttl),
+        'issuetype': issuetype,
     }
     if irc_channels is not None:
         result_dict['irc_channels'] = irc_channels

--- a/tests/test_pysensu_yelp.py
+++ b/tests/test_pysensu_yelp.py
@@ -27,6 +27,7 @@ class TestPySensuYelp:
     test_tags = ['tag1', 'tag2']
     test_ttl = '30M'
     test_cluster_name = 'test_cluster'
+    test_issuetype = 'Incident'
 
     event_dict = {
         'name': test_name,
@@ -48,6 +49,7 @@ class TestPySensuYelp:
         'source': test_source,
         'tags': test_tags,
         'ttl': pysensu_yelp.human_to_seconds(test_ttl),
+        'issuetype': test_issuetype,
     }
     event_dict['irc_channels'] = test_irc_channels
     event_dict['slack_channels'] = test_slack_channels
@@ -84,7 +86,8 @@ class TestPySensuYelp:
                                     source=self.test_source,
                                     tags=self.test_tags,
                                     ttl=self.test_ttl,
-                                    cluster_name=self.test_cluster_name)
+                                    cluster_name=self.test_cluster_name,
+                                    issuetype=self.test_issuetype)
             assert skt_patch.call_count == 1
             magic_skt.connect.assert_called_once_with(('169.254.255.254', 3030))
             magic_skt.sendall.assert_called_once_with(self.event_hash + b'\n')
@@ -111,7 +114,8 @@ class TestPySensuYelp:
                                     ttl=self.test_ttl,
                                     sensu_host='testhost',
                                     sensu_port=666,
-                                    cluster_name=self.test_cluster_name)
+                                    cluster_name=self.test_cluster_name,
+                                    issuetype=self.test_issuetype)
             assert skt_patch.call_count == 1
             magic_skt.connect.assert_called_once_with(('testhost', 666))
             magic_skt.sendall.assert_called_once_with(self.event_hash + b'\n')
@@ -137,7 +141,8 @@ class TestPySensuYelp:
                                         source=self.test_source,
                                         tags=self.test_tags,
                                         ttl=self.test_ttl,
-                                        cluster_name=self.test_cluster_name)
+                                        cluster_name=self.test_cluster_name,
+                                        issuetype=self.test_issuetype)
             skt_patch.assert_not_called()
 
     def test_no_special_characters_in_name(self):
@@ -162,4 +167,5 @@ class TestPySensuYelp:
                                             source=self.test_source,
                                             tags=self.test_tags,
                                             ttl=self.test_ttl,
-                                            cluster_name=self.test_cluster_name)
+                                            cluster_name=self.test_cluster_name,
+                                            issuetype=self.test_issuetype)


### PR DESCRIPTION
This allows for jira tickets to be more than just the default of ID 1 (aka "Bug") but other things like "Incident", etc.

I ran `make test` to test with the tests and have tested this parameter with sensu itself (I also tested that passing through `None` still leads to a ticket with the default value), but otherwise haven't tested anything else here. It's essentially a pass-through change though, so that makes it a bit simpler.