### PR TITLE
Build and test using Github Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,24 @@
+name: Build and Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['2.7', '3.6']
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+
+    - name: Install dependencies
+      run: python -m pip install tox
+
+    - name: Run ${{ matrix.python-version }} tox
+      run: tox -e py


### PR DESCRIPTION
Build and test using Github Actions.

Note: This does not publish the package to PyPI or publish docs. Those would be done in a
separate config.