### PR TITLE
Add trigger restrictions to GHA workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,10 @@
 name: Build and Test
 
-on: [push, pull_request]
+on:
+ push:
+   branches: [master]
+   tags:
+ pull_request:
 
 jobs:
   test:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,6 +1,10 @@
 name: Pre-commit Validation
 
-on: [push, pull_request]
+on:
+ push:
+   branches: [master]
+   tags:
+ pull_request:
 
 jobs:
   run:

--- a/.github/workflows/typing.yaml
+++ b/.github/workflows/typing.yaml
@@ -1,6 +1,10 @@
 name: Typing Validation
 
-on: [push, pull_request]
+on:
+ push:
+   branches: [master]
+   tags:
+ pull_request:
 
 jobs:
   run:


### PR DESCRIPTION
We only need to run these workflows on master and PRs.