### PR TITLE
upgrade python version and pin ubuntu version for publish workflow to fix and prevent errors in the future

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: 3.8
 
     - name: Install Python dependencies
       run: pip install wheel


### PR DESCRIPTION
This was previously using ubuntu-latest, which is currently jammy. Jammy doesn't have python 3.6. Upgrading it to 3.8 fixes that. In order to prevent this class of error in the future, I also pinned the ubuntu version to ubuntu-22.04 instead of ubuntu-latest.